### PR TITLE
chore: add baseline governance and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Instructions
+
+Agents working in this repository must:
+
+- Maintain per-file SPEC docs under `docs/spec/` mirroring the source tree.
+- Annotate code at the block level following the repository's documentation contracts.
+- Run `python validate_backlinks.py` before committing to ensure no orphan notes.
+
+For overall project goals, consult `plan.md`. Task queue details live in `toaster.md`.
+
+## Backlinks
+- [[plan.md]]
+- [[toaster.md]]
+- [[docs/README.md]]
+- [[README.md]]
+- [[CHANGELOG.md]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-06-15
+### Added
+- Initial project baseline with governance and documentation scaffolding.
+
+## Backlinks
+- [[AGENTS.md]]
+- [[plan.md]]
+- [[toaster.md]]
+- [[README.md]]
+- [[docs/CHANGELOG.md]]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![Analysis Status](https://img.shields.io/badge/analysis-ready%20for%20review-blue)](https://github.com/c1nderscript/platform-analysis-docs/issues/1)
 [![Platform Comparison](https://img.shields.io/badge/platforms-twitch%20%7C%20destiny.gg-orange)](./docs/architecture/cross-comparison.md)
 
+## Repository Governance
+
+See [AGENTS](AGENTS.md), [plan](plan.md), and [toaster](toaster.md) for contribution guidelines.
+
 ## 🚀 Quick Start
 
 **New to this analysis?** Start with the [**Project Summary**](./PROJECT_SUMMARY.md) for a complete overview.
@@ -93,3 +97,10 @@
 **Next Review**: September 15, 2025
 
 *For questions or feedback, please [create an issue](https://github.com/c1nderscript/platform-analysis-docs/issues/new) or review existing [discussions](https://github.com/c1nderscript/platform-analysis-docs/issues).*
+
+## Backlinks
+- [[AGENTS.md]]
+- [[plan.md]]
+- [[toaster.md]]
+- [[docs/README.md]]
+- [[CHANGELOG.md]]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Docs Changelog
+
+## [0.1.0] - 2024-06-15
+### Added
+- Established documentation baseline with README and changelog.
+
+## Backlinks
+- [[../AGENTS.md]]
+- [[../plan.md]]
+- [[../toaster.md]]
+- [[../README.md]]
+- [[../CHANGELOG.md]]
+- [[README.md]]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Platform Analysis Docs
+
+Repository: [platform-analysis-docs](../README.md)
+
+## Quick Start / Setup
+1. Clone the repo.
+2. Install Python 3.
+3. Run `python validate_backlinks.py` to verify documentation links.
+
+## Architecture
+```mermaid
+graph TD
+  A[Components] --> B[Docs]
+  B --> C[Rust Conversion]
+```
+
+## Usage
+- Review component docs under `Components/` and `destiny.gg Docs/`.
+- Consult `RUST CONVERSION/` for migration guides.
+
+## Prerequisites
+- Python 3
+- Git
+
+## Example Flow
+1. Update a component doc.
+2. Add or update its SPEC in `docs/spec/`.
+3. Run `python validate_backlinks.py`.
+
+## Contributing
+See [AGENTS instructions](../AGENTS.md) for contribution guidelines.
+
+## Backlinks
+- [[../AGENTS.md]]
+- [[../plan.md]]
+- [[../toaster.md]]
+- [[../README.md]]
+- [[../CHANGELOG.md]]
+- [[CHANGELOG.md]]

--- a/docs/spec/AGENTS.md.md
+++ b/docs/spec/AGENTS.md.md
@@ -1,0 +1,40 @@
+# AGENTS.md Spec
+
+## File Overview
+Provides operational guidelines for contributors and automated agents.
+
+## Public API Surface
+Defines expected workflows and required checks.
+
+## Type & Trait/Class Map
+N/A
+
+## Control & Data Flow
+Information-only; no runtime behavior.
+
+## Dependencies
+References `plan.md`, `toaster.md`, and `validate_backlinks.py`.
+
+## Error Model
+Misinterpretation leads to policy violations.
+
+## State & Concurrency
+Edited manually; no concurrent access concerns.
+
+## Performance Notes
+None.
+
+## Security Considerations
+Ensure instructions do not expose sensitive data.
+
+## Test Matrix
+- Run `python validate_backlinks.py` to confirm link integrity.
+
+## Maintenance Flags
+Keep instructions aligned with project practices.
+
+## Backlinks
+- [[../plan.md]]
+- [[../toaster.md]]
+- [[../README.md]]
+- [[../CHANGELOG.md]]

--- a/docs/spec/CHANGELOG.md.md
+++ b/docs/spec/CHANGELOG.md.md
@@ -1,0 +1,40 @@
+# CHANGELOG.md Spec
+
+## File Overview
+Tracks top-level changes and versions for the repository.
+
+## Public API Surface
+N/A
+
+## Type & Trait/Class Map
+N/A
+
+## Control & Data Flow
+Human-maintained record; no execution flow.
+
+## Dependencies
+Relies on contributors updating this file alongside version bumps.
+
+## Error Model
+Errors arise from inconsistent versioning or missing entries.
+
+## State & Concurrency
+Edited serially in git; no runtime state.
+
+## Performance Notes
+Negligible; file size scales with history.
+
+## Security Considerations
+Ensure entries are truthful and reviewed.
+
+## Test Matrix
+- Manual review of version bumps.
+
+## Maintenance Flags
+None.
+
+## Backlinks
+- [[../AGENTS.md]]
+- [[../plan.md]]
+- [[../toaster.md]]
+- [[../README.md]]

--- a/docs/spec/README.md.md
+++ b/docs/spec/README.md.md
@@ -1,0 +1,42 @@
+# README.md Spec
+
+## File Overview
+Primary repository landing page outlining project purpose and structure.
+
+## Public API Surface
+Links to key documentation and analysis resources.
+
+## Type & Trait/Class Map
+N/A
+
+## Control & Data Flow
+Serves as navigation guide; no runtime logic.
+
+## Dependencies
+References `AGENTS.md`, `plan.md`, `toaster.md`, and docs under `docs/`.
+
+## Error Model
+Outdated links or references mislead contributors.
+
+## State & Concurrency
+Updated with project milestones; edited via git.
+
+## Performance Notes
+Not applicable.
+
+## Security Considerations
+No sensitive data; ensure external links are safe.
+
+## Test Matrix
+- Validate hyperlinks using `validate_backlinks.py`.
+
+## Maintenance Flags
+Review periodically for accuracy.
+
+## Backlinks
+- [[AGENTS.md]]
+- [[plan.md]]
+- [[toaster.md]]
+- [[docs/README.md]]
+- [[CHANGELOG.md]]
+- [[../README.md]]

--- a/docs/spec/docs/CHANGELOG.md.md
+++ b/docs/spec/docs/CHANGELOG.md.md
@@ -1,0 +1,42 @@
+# docs/CHANGELOG.md Spec
+
+## File Overview
+Records versioned changes within the `docs/` directory.
+
+## Public API Surface
+N/A
+
+## Type & Trait/Class Map
+N/A
+
+## Control & Data Flow
+Chronological log of documentation updates.
+
+## Dependencies
+Aligned with root `CHANGELOG.md` for overall release notes.
+
+## Error Model
+Omitting entries causes mismatched history.
+
+## State & Concurrency
+Sequential edits tracked by git.
+
+## Performance Notes
+None.
+
+## Security Considerations
+Ensure entries do not reveal sensitive plans.
+
+## Test Matrix
+- Manual review of doc updates.
+
+## Maintenance Flags
+Synchronize with root changelog when docs change.
+
+## Backlinks
+- [[../../AGENTS.md]]
+- [[../../plan.md]]
+- [[../../toaster.md]]
+- [[../../README.md]]
+- [[../README.md]]
+- [[../../CHANGELOG.md]]

--- a/docs/spec/docs/README.md.md
+++ b/docs/spec/docs/README.md.md
@@ -1,0 +1,42 @@
+# docs/README.md Spec
+
+## File Overview
+Introduces the documentation subsystem and provides setup instructions.
+
+## Public API Surface
+Links to component docs, Rust conversion guides, and contribution guidelines.
+
+## Type & Trait/Class Map
+N/A
+
+## Control & Data Flow
+Guides users through typical documentation workflows.
+
+## Dependencies
+Depends on root `AGENTS.md` for contribution rules and `validate_backlinks.py` for integrity checks.
+
+## Error Model
+Missing prerequisites or stale instructions may block contributors.
+
+## State & Concurrency
+Edited manually; no concurrent runtime state.
+
+## Performance Notes
+N/A
+
+## Security Considerations
+Ensure external references are trustworthy.
+
+## Test Matrix
+- Run `python validate_backlinks.py`.
+
+## Maintenance Flags
+Update Quick Start and diagram as tooling evolves.
+
+## Backlinks
+- [[../../AGENTS.md]]
+- [[../../plan.md]]
+- [[../../toaster.md]]
+- [[../../README.md]]
+- [[../CHANGELOG.md]]
+- [[../README.md]]

--- a/docs/spec/plan.md.md
+++ b/docs/spec/plan.md.md
@@ -1,0 +1,40 @@
+# plan.md Spec
+
+## File Overview
+Outlines high-level objectives and future direction for documentation efforts.
+
+## Public API Surface
+N/A
+
+## Type & Trait/Class Map
+N/A
+
+## Control & Data Flow
+Serves as a reference for planning; no execution flow.
+
+## Dependencies
+Links to `AGENTS.md` and `toaster.md` for actionable details.
+
+## Error Model
+Outdated plans may misguide contributors.
+
+## State & Concurrency
+Updated manually as priorities shift.
+
+## Performance Notes
+Irrelevant.
+
+## Security Considerations
+Avoid including sensitive roadmap details.
+
+## Test Matrix
+- Manual review during planning cycles.
+
+## Maintenance Flags
+Revise as project scope evolves.
+
+## Backlinks
+- [[../AGENTS.md]]
+- [[../toaster.md]]
+- [[../README.md]]
+- [[../CHANGELOG.md]]

--- a/docs/spec/toaster.md.md
+++ b/docs/spec/toaster.md.md
@@ -1,0 +1,40 @@
+# toaster.md Spec
+
+## File Overview
+Captures short-lived tasks and immediate action items.
+
+## Public API Surface
+N/A
+
+## Type & Trait/Class Map
+N/A
+
+## Control & Data Flow
+Used as a simple list; tasks are added and removed manually.
+
+## Dependencies
+Informed by `plan.md` and guided by `AGENTS.md` policies.
+
+## Error Model
+Stale entries may cause confusion about project status.
+
+## State & Concurrency
+Sequential edits through git.
+
+## Performance Notes
+Not applicable.
+
+## Security Considerations
+Do not log sensitive operational details.
+
+## Test Matrix
+- Manual cleanup review.
+
+## Maintenance Flags
+Ensure tasks are triaged or archived promptly.
+
+## Backlinks
+- [[../AGENTS.md]]
+- [[../plan.md]]
+- [[../README.md]]
+- [[../CHANGELOG.md]]

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,12 @@
+# Project Plan
+
+This repository tracks documentation for platform analysis. Initial focus is to catalogue components and guide Rust migrations.
+
+Future work will expand coverage of frontend and backend modules.
+
+## Backlinks
+- [[AGENTS.md]]
+- [[toaster.md]]
+- [[docs/README.md]]
+- [[README.md]]
+- [[CHANGELOG.md]]

--- a/toaster.md
+++ b/toaster.md
@@ -1,0 +1,10 @@
+# Toaster
+
+This file tracks immediate tasks and hot fixes. Add short-lived items here and remove them once complete.
+
+## Backlinks
+- [[AGENTS.md]]
+- [[plan.md]]
+- [[docs/README.md]]
+- [[README.md]]
+- [[CHANGELOG.md]]


### PR DESCRIPTION
## Summary
- establish root governance docs (AGENTS, plan, toaster)
- add changelogs and documentation README with quick start and diagram
- introduce spec docs mirroring new files

## Testing
- `python validate_backlinks.py`
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b19a866b4c8332a2b55bd54564bd75